### PR TITLE
Correcting comment redefinition

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -18,9 +18,33 @@
 			</dict>
 			<dict>
 				<key>name</key>
-				<string>TM_COMMENT_START</string>
+				<string>TM_COMMENT_START_2</string>
+				<key>value</key>
+				<string>--[[ </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_2</string>
+				<key>value</key>
+				<string>--]] </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_3</string>
 				<key>value</key>
 				<string>// </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_4</string>
+				<key>value</key>
+				<string>/* </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_4</string>
+				<key>value</key>
+				<string>*/ </string>
 			</dict>
 		</array>
 	</dict>


### PR DESCRIPTION
Duplicated block (with the same <string> id) was inserting C++ comment style (//) instead of Lua comment style (--).
This causes bug's when editing pure Lua, so I added support to various style. Including the ones supported by GMod.